### PR TITLE
ConfigureContainer has to use services of module host

### DIFF
--- a/src/Hosuto.Abstractions/Modules/Hosting/IModuleHostOptions.cs
+++ b/src/Hosuto.Abstractions/Modules/Hosting/IModuleHostOptions.cs
@@ -15,5 +15,8 @@ namespace Dbosoft.Hosuto.Modules.Hosting
         IModuleHostingOptions Configure<TContext>(Action<TContext> configureAction)
             where TContext : class, IModuleContext;
 
+        IModuleHostingOptions ModuleFactoryCallback(Func<IServiceProvider, IModule> moduleFactory);
+
+
     }
 }

--- a/src/Hosuto.Hosting/Modules/Hosting/Internal/ModuleHostingOptions.cs
+++ b/src/Hosuto.Hosting/Modules/Hosting/Internal/ModuleHostingOptions.cs
@@ -11,6 +11,8 @@ namespace Dbosoft.Hosuto.Modules.Hosting.Internal
 
         public Action<IModuleContext> ConfigureContextAction { get; private set; }
 
+        public Func<IServiceProvider, IModule> ModuleFactory { get; private set; }
+
         public bool ConfigureContextCalled { get; set; }
 
         public IDictionary<string, object> Properties { get; } = new Dictionary<string, object>();
@@ -36,6 +38,12 @@ namespace Dbosoft.Hosuto.Modules.Hosting.Internal
         public IModuleHostingOptions Configure<TContext>(Action<TContext> configureAction) where TContext : class, IModuleContext
         {
             ConfigureContextAction = (ctx) => configureAction(ctx as TContext);
+            return this;
+        }
+
+        public IModuleHostingOptions ModuleFactoryCallback(Func<IServiceProvider, IModule> moduleFactory)
+        {
+            ModuleFactory = moduleFactory;
             return this;
         }
     }

--- a/src/Hosuto.Hosting/Modules/Hosting/ModulesHostBuilder.cs
+++ b/src/Hosuto.Hosting/Modules/Hosting/ModulesHostBuilder.cs
@@ -117,9 +117,14 @@ namespace Dbosoft.Hosuto.Modules.Hosting
                 var moduleHostServicesFactory = frameworkServices.GetService<IModuleHostServiceProviderFactory>();
                 moduleHostServicesFactoryState = moduleHostServicesFactory?.ConfigureServices(services);
 
-                foreach (var moduleType in _registeredModules.Keys)
+                foreach (var module in _registeredModules)
                 {
-                    services.AddSingleton(moduleType);
+                    
+                    if(module.Value.ModuleFactory==null)
+                        services.AddSingleton(module.Key);
+                    else
+                        services.AddSingleton(module.Key, module.Value.ModuleFactory);
+
                 }
 
                 RegisterModulesAndHosts(services, frameworkServices);

--- a/src/Hosuto.SimpleInjector/Modules/Hosting/HostFactoryDecorator.cs
+++ b/src/Hosuto.SimpleInjector/Modules/Hosting/HostFactoryDecorator.cs
@@ -18,7 +18,7 @@ namespace Dbosoft.Hosuto.Modules.Hosting
 
         private void UseSimpleInjector<TModule>(IModuleContext<TModule> moduleContext, SimpleInjectorUseOptions options) where TModule: IModule
         {
-            ModuleMethodInvoker.CallOptionalMethod(moduleContext.ToBootstrapContext(), "UseSimpleInjector", moduleContext.Services, options);
+            ModuleMethodInvoker.CallOptionalMethod(moduleContext.ToBootstrapContext(), "UseSimpleInjector", moduleContext.Advanced.HostServices, options);
         }
 
         private void ConfigureContainer<TModule>(IModuleContext<TModule> moduleContext, Container container) where TModule : IModule
@@ -28,7 +28,7 @@ namespace Dbosoft.Hosuto.Modules.Hosting
                 configurer.ConfigureContainer(moduleContext, container);
             }
 
-            ModuleMethodInvoker.CallOptionalMethod(moduleContext.ToBootstrapContext(), "ConfigureContainer", moduleContext.Services, container);
+            ModuleMethodInvoker.CallOptionalMethod(moduleContext.ToBootstrapContext(), "ConfigureContainer", moduleContext.Advanced.HostServices, container);
         }
 
         public (IHost Host, IModuleContext<TModule> ModuleContext) CreateHost<TModule>(IModuleBootstrapContext<TModule> bootstrapContext, ModuleHostingOptions options) where TModule : IModule

--- a/test/Hosuto.SimpleInjector.Tests/Hosuto.SimpleInjector.Tests.csproj
+++ b/test/Hosuto.SimpleInjector.Tests/Hosuto.SimpleInjector.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/Hosuto.SimpleInjector.Tests/Modules/Hosting/ConfigureContainerTests.cs
+++ b/test/Hosuto.SimpleInjector.Tests/Modules/Hosting/ConfigureContainerTests.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using Dbosoft.Hosuto.Modules;
+using Dbosoft.Hosuto.Modules.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using SimpleInjector;
+using Xunit;
+
+namespace Hosuto.SimpleInjector.Tests.Modules.Hosting
+{
+    public class ConfigureContainerTests
+    {
+
+        [Fact]
+        public void ConfigureContainer_is_called()
+        {
+
+            var moduleMock = new Mock<ModuleWithConfigureContainer>();
+            moduleMock.Setup(x => x.ConfigureContainer(
+                It.IsAny<Container>())).Verifiable();
+
+            BuildAndVerifyModuleMock(moduleMock);
+
+        }
+
+        [Fact]
+        public void ConfigureContainer_with_ServiceProvider_is_called()
+        {
+            var container = new Container();
+
+            var moduleMock = new Mock<ModuleWithConfigureContainerAndServiceProvider>();
+            moduleMock.Setup(x => x.ConfigureContainer(
+                It.Is<IServiceProvider>(sp => ReferenceEquals(sp, container)),
+                It.IsAny<Container>())).Verifiable();
+
+            BuildAndVerifyModuleMock(moduleMock, container);
+
+        }
+
+        [Fact]
+        public void ConfigureContainer_with_Injection_is_called()
+        {
+            var moduleMock = new Mock<ModuleWithConfigureContainerAndInjection>();
+            moduleMock.Setup(x => x.ConfigureContainer(
+                It.IsAny<Container>(), It.IsAny<IHostingEnvironment>())).Verifiable();
+
+            BuildAndVerifyModuleMock(moduleMock);
+
+        }
+
+        private void BuildAndVerifyModuleMock<TModule>(Mock<TModule> moduleMock, Container container = null) where TModule : class, IModule
+        {
+            var builder = ModulesHost.CreateDefaultBuilder();
+
+            if (container == null)
+                builder.UseSimpleInjector();
+            else
+                builder.UseSimpleInjector(container);
+
+            builder.HostModule<TModule>(
+                options => options.ModuleFactoryCallback(_ => moduleMock.Object));
+
+            builder.Build().Dispose();
+
+            moduleMock.Verify();
+        }
+
+        [Fact]
+        public void ConfigureContainer_extensions_are_called()
+        {
+            var configureMock = new Mock<IContainerConfigurer<ModuleWithConfigureContainer>>();
+            configureMock.Setup(x =>
+                x.ConfigureContainer(It.IsAny<IModuleContext<ModuleWithConfigureContainer>>(), It.IsAny<Container>())
+            ).Verifiable();
+
+            var builder = ModulesHost.CreateDefaultBuilder();
+            builder.UseSimpleInjector();
+            builder.HostModule<ModuleWithConfigureContainer>();
+            builder.ConfigureFrameworkServices((ctx, services) => services.AddTransient(sp => configureMock.Object));
+            builder.Build().Dispose();
+
+            configureMock.Verify();
+
+
+        }
+
+        public class ModuleWithConfigureContainer : IModule
+        {
+            public string Name  => nameof(ModuleWithConfigureContainer);
+
+
+            public virtual void ConfigureContainer(Container container)
+            {}
+
+        }
+
+        public  class ModuleWithConfigureContainerAndInjection : IModule
+        {
+            public string Name => nameof(ModuleWithConfigureContainerAndInjection);
+
+
+            public virtual void ConfigureContainer(Container container, IHostingEnvironment env)
+            {}
+
+        }
+
+
+        public class ModuleWithConfigureContainerAndServiceProvider : IModule
+        {
+            public string Name => nameof(ModuleWithConfigureContainerAndServiceProvider);
+
+            public virtual void ConfigureContainer(IServiceProvider sp, Container container){}
+        }
+
+    }
+}

--- a/test/Hosuto.SimpleInjector.Tests/Modules/Hosting/InnerContainerTests.cs
+++ b/test/Hosuto.SimpleInjector.Tests/Modules/Hosting/InnerContainerTests.cs
@@ -2,13 +2,14 @@
 using Dbosoft.Hosuto.Modules;
 using Dbosoft.Hosuto.Modules.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Moq;
 using SimpleInjector;
 using Xunit;
 
 namespace Hosuto.SimpleInjector.Tests.Modules.Hosting
 {
-    public class UseContainerTests
+    public class InnerContainerTests
     {
         [Fact]
         public void Module_uses_SimpleInjector_as_inner_container()
@@ -20,6 +21,50 @@ namespace Hosuto.SimpleInjector.Tests.Modules.Hosting
             var moduleHost = host.Services.GetRequiredService<IModuleHost<SomeModule>>();
             Assert.IsType<Container>(moduleHost.ModuleContext.Services);
             host.Dispose();
+        }
+
+
+        [Fact]
+        public void ConfigureContainer_is_called()
+        {
+
+            var moduleMock = new Mock<ModuleWithConfigureContainer>();
+            moduleMock.Setup(x => x.ConfigureContainer(
+                It.IsAny<Container>())).Verifiable();
+
+            BuildAndVerifyModuleMock(moduleMock);
+
+        }
+
+        [Fact]
+        public void ConfigureContainer_with_ServiceProvider_is_called()
+        {
+            var container = new Container();
+            
+            var moduleMock = new Mock<ModuleWithConfigureContainerAndServiceProvider>();
+            moduleMock.Setup(x => x.ConfigureContainer(
+                     It.Is<IServiceProvider>(sp=> ReferenceEquals(sp, container)),
+                     It.IsAny<Container>())).Verifiable();
+
+            BuildAndVerifyModuleMock(moduleMock, container);
+
+        }
+
+        private void BuildAndVerifyModuleMock<TModule>(Mock<TModule> moduleMock, Container container = null) where TModule : class, IModule
+        {
+            var builder = ModulesHost.CreateDefaultBuilder();
+
+            if (container == null)
+                builder.UseSimpleInjector();
+            else
+                builder.UseSimpleInjector(container);
+
+            builder.HostModule<SomeModule>(
+                options => options.ModuleFactoryCallback(_ => moduleMock.Object));
+
+            builder.Build().Dispose();
+
+            moduleMock.Verify();
         }
 
         [Fact]
@@ -44,8 +89,40 @@ namespace Hosuto.SimpleInjector.Tests.Modules.Hosting
         public class SomeModule : IModule
         {
             public string Name => "I'm a module";
-            
+
+
+            public virtual void ConfigureContainer(Container container, IHostingEnvironment env)
+            {
+
+            }
         }
+
+        public abstract class ModuleWithConfigureContainer : IModule
+        {
+            public abstract string Name { get; }
+
+
+            public abstract void ConfigureContainer(Container container);
+
+        }
+
+        public abstract class ModuleWithConfigureContainerAndInjection : IModule
+        {
+            public abstract string Name { get; }
+
+
+            public abstract void ConfigureContainer(Container container, IHostingEnvironment env);
+
+        }
+
+
+        public abstract class ModuleWithConfigureContainerAndServiceProvider : IModule
+        {
+            public abstract string Name { get;  }
+
+            public abstract void ConfigureContainer(IServiceProvider sp, Container container);
+        }
+
     }
 
     

--- a/test/Hosuto.SimpleInjector.Tests/Modules/Hosting/InnerContainerTests.cs
+++ b/test/Hosuto.SimpleInjector.Tests/Modules/Hosting/InnerContainerTests.cs
@@ -24,67 +24,6 @@ namespace Hosuto.SimpleInjector.Tests.Modules.Hosting
         }
 
 
-        [Fact]
-        public void ConfigureContainer_is_called()
-        {
-
-            var moduleMock = new Mock<ModuleWithConfigureContainer>();
-            moduleMock.Setup(x => x.ConfigureContainer(
-                It.IsAny<Container>())).Verifiable();
-
-            BuildAndVerifyModuleMock(moduleMock);
-
-        }
-
-        [Fact]
-        public void ConfigureContainer_with_ServiceProvider_is_called()
-        {
-            var container = new Container();
-            
-            var moduleMock = new Mock<ModuleWithConfigureContainerAndServiceProvider>();
-            moduleMock.Setup(x => x.ConfigureContainer(
-                     It.Is<IServiceProvider>(sp=> ReferenceEquals(sp, container)),
-                     It.IsAny<Container>())).Verifiable();
-
-            BuildAndVerifyModuleMock(moduleMock, container);
-
-        }
-
-        private void BuildAndVerifyModuleMock<TModule>(Mock<TModule> moduleMock, Container container = null) where TModule : class, IModule
-        {
-            var builder = ModulesHost.CreateDefaultBuilder();
-
-            if (container == null)
-                builder.UseSimpleInjector();
-            else
-                builder.UseSimpleInjector(container);
-
-            builder.HostModule<SomeModule>(
-                options => options.ModuleFactoryCallback(_ => moduleMock.Object));
-
-            builder.Build().Dispose();
-
-            moduleMock.Verify();
-        }
-
-        [Fact]
-        public void ConfigureContainer_extensions_are_called()
-        {
-            var configureMock = new Mock<IContainerConfigurer<SomeModule>>();
-            configureMock.Setup(x => 
-                x.ConfigureContainer(It.IsAny<IModuleContext<SomeModule>>(), It.IsAny<Container>())
-            ).Verifiable();
-
-            var builder = ModulesHost.CreateDefaultBuilder();
-            builder.UseSimpleInjector();
-            builder.HostModule<SomeModule>();
-            builder.ConfigureFrameworkServices((ctx, services) => services.AddTransient(sp=>configureMock.Object));
-            builder.Build().Dispose();
-
-            configureMock.Verify();
-
-
-        }
 
         public class SomeModule : IModule
         {
@@ -95,32 +34,6 @@ namespace Hosuto.SimpleInjector.Tests.Modules.Hosting
             {
 
             }
-        }
-
-        public abstract class ModuleWithConfigureContainer : IModule
-        {
-            public abstract string Name { get; }
-
-
-            public abstract void ConfigureContainer(Container container);
-
-        }
-
-        public abstract class ModuleWithConfigureContainerAndInjection : IModule
-        {
-            public abstract string Name { get; }
-
-
-            public abstract void ConfigureContainer(Container container, IHostingEnvironment env);
-
-        }
-
-
-        public abstract class ModuleWithConfigureContainerAndServiceProvider : IModule
-        {
-            public abstract string Name { get;  }
-
-            public abstract void ConfigureContainer(IServiceProvider sp, Container container);
         }
 
     }


### PR DESCRIPTION
ConfigureContainer has to use services of module host (Services will be the container when calling ConfigureContainer).

fixes #9

Added unit tests for ConfigureContainer variants and a callback to module options to inject module instance.