### PR TITLE
replaced GitVersionTask with GitVersion.MsBuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -271,3 +271,4 @@ nwrfcsdk/x86/demo
 nwrfcsdk/x86/doc
 nwrfcsdk/x86/include
 nwrfcsdk/x86/lib
+gitversion.json

--- a/src/Hosuto.Abstractions/Hosuto.Abstractions.csproj
+++ b/src/Hosuto.Abstractions/Hosuto.Abstractions.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.3.7">
+    <PackageReference Include="GitVersion.MsBuild" Version="5.6.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Hosuto.Hosting.AspNetCore/Hosuto.Hosting.AspNetCore.csproj
+++ b/src/Hosuto.Hosting.AspNetCore/Hosuto.Hosting.AspNetCore.csproj
@@ -28,7 +28,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.3.7">
+    <PackageReference Include="GitVersion.MsBuild" Version="5.6.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Hosuto.Hosting/Hosuto.Hosting.csproj
+++ b/src/Hosuto.Hosting/Hosuto.Hosting.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.3.7">
+    <PackageReference Include="GitVersion.MsBuild" Version="5.6.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Hosuto.SimpleInjector/Hosuto.SimpleInjector.csproj
+++ b/src/Hosuto.SimpleInjector/Hosuto.SimpleInjector.csproj
@@ -9,7 +9,7 @@
   <Import Project="..\..\build\pack.props" />
 
   <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.3.7">
+    <PackageReference Include="GitVersion.MsBuild" Version="5.6.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Hosuto.Testing.AspNetCore/Hosuto.Testing.AspNetCore.csproj
+++ b/src/Hosuto.Testing.AspNetCore/Hosuto.Testing.AspNetCore.csproj
@@ -35,7 +35,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.3.7">
+    <PackageReference Include="GitVersion.MsBuild" Version="5.6.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Hosuto/Hosuto.csproj
+++ b/src/Hosuto/Hosuto.csproj
@@ -9,7 +9,7 @@
   <Import Project="..\..\build\pack.props" />
 
   <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.3.7">
+    <PackageReference Include="GitVersion.MsBuild" Version="5.6.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
package GitVersionTask is deprecated. Now package name: GitVersion.MsBuild