### PR TITLE
fix pipeline order

### DIFF
--- a/src/Hosuto.Hosting.AspNetCore/Modules/Hosting/WebModuleBootstrapHostHandler.cs
+++ b/src/Hosuto.Hosting.AspNetCore/Modules/Hosting/WebModuleBootstrapHostHandler.cs
@@ -89,7 +89,7 @@ namespace Dbosoft.Hosuto.Modules.Hosting
                             });
                             
 
-                        })).Reverse());
+                        })));
             ApplyConfiguration(builder);
 
             command.Options.ConfigureBuilderAction?.Invoke(builder);
@@ -221,7 +221,7 @@ namespace Dbosoft.Hosuto.Modules.Hosting
             return (services =>
             {
 #pragma warning disable CS0612 // Type or member is obsolete
-            var filters = serviceProvider.GetRequiredService<IEnumerable<IStartupConfigureServicesFilter>>().Reverse().ToArray();
+            var filters = serviceProvider.GetRequiredService<IEnumerable<IStartupConfigureServicesFilter>>().ToArray();
 #pragma warning restore CS0612 // Type or member is obsolete
 
             if (filters.Length == 0)

--- a/src/Hosuto.Hosting/Filters.cs
+++ b/src/Hosuto.Hosting/Filters.cs
@@ -13,7 +13,7 @@ namespace Dbosoft.Hosuto
 
             return (p1 =>
             {
-                var enumerable = filters.ToList();
+                var enumerable = filters.Reverse().ToList();
                 if (enumerable.Count == 0)
                 {
                     filteredDelegate(p1);
@@ -31,7 +31,7 @@ namespace Dbosoft.Hosuto
             if (filteredDelegate == null) throw new ArgumentNullException(nameof(filteredDelegate));
             return ((p1, p2) =>
             {
-                var enumerable = filters.ToList();
+                var enumerable = filters.Reverse().ToList();
                 if (enumerable.Count == 0)
                 {
                     filteredDelegate(p1,p2);

--- a/src/Hosuto.Hosting/Modules/Hosting/Internal/DelegateModuleHostBuilderConfigurationConfigurer.cs
+++ b/src/Hosuto.Hosting/Modules/Hosting/Internal/DelegateModuleHostBuilderConfigurationConfigurer.cs
@@ -22,11 +22,8 @@ namespace Dbosoft.Hosuto.Modules.Hosting.Internal
         {
             return (ctx, config) =>
             {
-                //configuration has to be applied in reversed order, so first all 
-                //other filters than override
-                next(ctx, config);
                 _configureDelegate(ctx, config);
-
+                next(ctx, config);
             };
         }
     }


### PR DESCRIPTION
no moe need to reverse it later as currently done ConfigureServices and ConfigureAppConfiguration.

Not classified as bug, as we just have changed place where order of filters is reversed.