### PR TITLE
module constructor injection for simpleinjector

### DIFF
--- a/src/Hosuto.Abstractions/Modules/Hosting/IModuleHostServiceProviderFactory.cs
+++ b/src/Hosuto.Abstractions/Modules/Hosting/IModuleHostServiceProviderFactory.cs
@@ -7,5 +7,8 @@ namespace Dbosoft.Hosuto.Modules.Hosting
     {
         object ConfigureServices(IServiceCollection services);
         IServiceProvider ReplaceServiceProvider(object state, IServiceProvider services);
+
+        void ConfigureModule(Type moduleType, Func<IServiceProvider,object> moduleFactory);
+
     }
 }

--- a/src/Hosuto.Hosting/Modules/Hosting/ModulesHostBuilder.cs
+++ b/src/Hosuto.Hosting/Modules/Hosting/ModulesHostBuilder.cs
@@ -123,12 +123,13 @@ namespace Dbosoft.Hosuto.Modules.Hosting
 
                 foreach (var module in _registeredModules)
                 {
-                    
-                    if(module.Value.ModuleFactory==null)
+                    moduleHostServicesFactory?.ConfigureModule(module.Key, module.Value.ModuleFactory);
+                    if (moduleHostServicesFactory != null) continue;
+
+                    if (module.Value.ModuleFactory == null)
                         services.AddSingleton(module.Key);
                     else
                         services.AddSingleton(module.Key, module.Value.ModuleFactory);
-
                 }
 
                 RegisterModulesAndHosts(services, frameworkServices);

--- a/src/Hosuto.SimpleInjector/Modules/Hosting/ServiceProviderFactory.cs
+++ b/src/Hosuto.SimpleInjector/Modules/Hosting/ServiceProviderFactory.cs
@@ -30,6 +30,20 @@ namespace Dbosoft.Hosuto.Modules.Hosting
 
             return _container;
         }
+
+        public void ConfigureModule(Type moduleType, Func<IServiceProvider, object> moduleFactory)
+        {
+
+            switch (moduleFactory)
+            {
+                case null:
+                    _container.Register(moduleType);
+                    break;
+                default:
+                    _container.Register(moduleType, () => moduleFactory(_container) );
+                    break;
+            }
+        }
     }
     
 }

--- a/test/Hosuto.Hosting.Tests/Modules/Hosting/ModuleBuildingTests.cs
+++ b/test/Hosuto.Hosting.Tests/Modules/Hosting/ModuleBuildingTests.cs
@@ -88,6 +88,25 @@ namespace Hosuto.Hosting.Tests.Modules.Hosting
             Assert.NotNull(module.SomeModule);
         }
 
+
+        [Fact]
+        public void Module_dependencies_can_be_injected_from_host_container()
+        {
+            var builder = ModulesHost.CreateDefaultBuilder();
+            builder.HostModule<ModuleWithConstructorInjection>();
+
+            var depMock = Mock.Of<IDep>();
+            var sc = new ServiceCollection();
+            sc.AddTransient(sp => depMock);
+
+            builder.UseServiceCollection(sc);
+
+            var host = builder.Build();
+            var module = host.Services.GetRequiredService<ModuleWithConstructorInjection>();
+
+            Assert.Equal(depMock,module.Dependency);
+        }
+
         private class SomeModule
         {
             public string Environment { get; private set; }
@@ -104,6 +123,21 @@ namespace Hosuto.Hosting.Tests.Modules.Hosting
             {
                 Environment = environment.EnvironmentName;
                 Configuration = configuration;
+            }
+
+        }
+
+        public interface IDep
+        {
+            
+        }
+
+        private class ModuleWithConstructorInjection
+        {
+            public IDep Dependency { get;  }
+            public ModuleWithConstructorInjection(IDep dep)
+            {
+                Dependency = dep;
             }
 
         }


### PR DESCRIPTION
With simpleinjector dependencies cannot be injected if they are registered in outer container.

This PR also fixes the issue that the module is not registered in outer container after building the ModulesHost (like the default ServiceCollection container).
